### PR TITLE
Add an auth option for connecting with the redis server.

### DIFF
--- a/lib/primus-redis-rooms.js
+++ b/lib/primus-redis-rooms.js
@@ -17,7 +17,11 @@ var PrimusRedisRooms = module.exports = function (primus, options) {
       );
     }
 
-    return redis.createClient(options.redis);
+    client = redis.createClient(options.redis);
+    if (options.redis.auth) {
+      client.auth(options.redis.auth)
+    }
+    return client;
   }
 
   channel = options.redis.channel || 'primus';


### PR DESCRIPTION
As described in #1 the current primus-redis-rooms library is ignoring
any possible auth. This fixes it for the standalon redis server. Not
sure if it fixes it for the sentinel setup too (have no setup to test).
