### PR TITLE
Fixed parameters for redis.createClient

### DIFF
--- a/lib/primus-redis-rooms.js
+++ b/lib/primus-redis-rooms.js
@@ -16,7 +16,7 @@ var PrimusRedisRooms = module.exports = function (primus, options) {
       );
     }
 
-    return redis.createClient(options.redis);
+    return redis.createClient(options.redis.port, options.redis.host, options.redis);
   }
 
   channel = options.redis.channel || 'primus';


### PR DESCRIPTION
Redis was not connecting to configured servers. The `redis.createClient` function was not being passed the port and host.
